### PR TITLE
Newer mongodb installs do not like localhost

### DIFF
--- a/lib/mongo_sync.rb
+++ b/lib/mongo_sync.rb
@@ -52,7 +52,7 @@ class Heroku::Command::Mongo < Heroku::Command::Base
   end
 
   def local_mongo_uri
-    url = ENV["MONGO_URL"] || "mongodb://localhost:27017/#{app}"
+    url = ENV["MONGO_URL"] || "mongodb://127.0.0.1:27017/#{app}"
 
     URI.parse url
   end


### PR DESCRIPTION
You get and error saying that it cannot connect to the database. Using the local ip works.