### PR TITLE
Add files attribute to package json to prevent errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "co": "4.6.0",
     "heroku-cli-util": "5.8.0",
     "mongodb-url": "1.0.3"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Adds `files` attribute to `package.json` to prevent errors introduced with `npm` version 6